### PR TITLE
Add password update page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,7 @@ import InterviewCoaching from "./pages/services/InterviewCoaching";
 import SignIn from "./pages/auth/SignIn";
 import SignUp from "./pages/auth/SignUp";
 import ResetPassword from "./pages/auth/ResetPassword";
+import UpdatePassword from "./pages/auth/UpdatePassword";
 import AuthLayout from "./components/layouts/AuthLayout";
 import ProtectedRoute from "./components/auth/ProtectedRoute";
 
@@ -68,6 +69,7 @@ const App = () => {
                   <Route path="/sign-in" element={<SignIn />} />
                   <Route path="/sign-up" element={<SignUp />} />
                   <Route path="/reset-password" element={<ResetPassword />} />
+                  <Route path="/update-password" element={<UpdatePassword />} />
                 </Route>
                 
                 {/* Dashboard Routes */}

--- a/src/pages/auth/UpdatePassword.tsx
+++ b/src/pages/auth/UpdatePassword.tsx
@@ -1,0 +1,75 @@
+import React, { useState } from 'react';
+import { useNavigate, Link } from 'react-router-dom';
+import { useSupabaseClient } from '@supabase/auth-helpers-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+import { toast } from '@/components/ui/use-toast';
+
+const UpdatePassword = () => {
+  const supabase = useSupabaseClient();
+  const navigate = useNavigate();
+  const [password, setPassword] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleUpdatePassword = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsLoading(true);
+    try {
+      const { error } = await supabase.auth.updateUser({ password });
+      if (error) throw error;
+
+      toast({
+        title: 'Password updated',
+        description: 'You can now sign in with your new password.',
+      });
+      navigate('/sign-in');
+    } catch (error: any) {
+      console.error('Update password error:', error);
+      toast({
+        title: 'Error',
+        description: error.message || 'Failed to update password. Please try again.',
+        variant: 'destructive',
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader className="space-y-1">
+        <CardTitle className="text-2xl">Set a new password</CardTitle>
+        <CardDescription>Enter your new password below.</CardDescription>
+      </CardHeader>
+      <CardContent className="grid gap-4">
+        <form onSubmit={handleUpdatePassword} className="space-y-4">
+          <div className="grid gap-2">
+            <Label htmlFor="password">New Password</Label>
+            <Input
+              id="password"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+              autoComplete="new-password"
+            />
+          </div>
+          <Button disabled={isLoading} type="submit" className="w-full">
+            {isLoading ? 'Updating...' : 'Update Password'}
+          </Button>
+        </form>
+      </CardContent>
+      <CardFooter>
+        <p className="text-center text-sm text-gray-600 mt-2 w-full">
+          <Link to="/sign-in" className="text-blue-600 hover:text-blue-800">
+            Back to sign in
+          </Link>
+        </p>
+      </CardFooter>
+    </Card>
+  );
+};
+
+export default UpdatePassword;


### PR DESCRIPTION
## Summary
- add an `UpdatePassword` page for users completing the password reset flow
- register new page in the router

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684c08253c98833292e3b606e7660b0e